### PR TITLE
Working in Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 /** @module browsersavefile */
 
-var URL = window.URL || window.webkitURL;
+var URL = typeof window !== 'undefined' && (window.URL || window.webkitURL);
+
+var link;
+if (typeof document !== 'undefined') {
+	link = document.createElement( 'a' );
+	link.style = 'display: none';
+	document.body.appendChild( link );
+}
 
 /**
  * browsersavefile will take a file name and a Blob object. It will then
@@ -25,12 +32,11 @@ module.exports = function browsersavefile( fileName, blob ) {
 		throw new Error( 'URL is not supported cannot download file' );
 
 	var url = URL.createObjectURL( blob );
-	
-	var clickEV = document.createEvent( 'Event' );
-	clickEV.initEvent( 'click', true, true);
-
-	var link = document.createElement( 'a' );
 	link.href = url;
 	link.download = fileName;
-	link.dispatchEvent( clickEV );
+	link.click();
+
+	setTimeout(function cleanupBlob() {
+		URL.revokeObjectURL( url );
+	});
 };


### PR DESCRIPTION
- Firefox needs the link to be part of the DOM before clicking it
- Cleans up blob after download
- Save to require from node (e.g. to use it in a react component that might be rendered on the server)

Tested in Chrome and Firefox.
